### PR TITLE
add diabetes phenotype test for strider

### DIFF
--- a/strider/diabetes_phenotype.watchdog.json
+++ b/strider/diabetes_phenotype.watchdog.json
@@ -1,0 +1,51 @@
+{
+	"name": "Diabetes Phenotype",
+	"target": "https://strider.renci.org/1.2/query",
+	"expectations": [
+		{
+			"selector": ".message.knowledge_graph.nodes[\"MONDO:0005148\"].name",
+			"value": "type 2 diabetes mellitus",
+			"validation_type": "string"
+		},
+		{
+			"selector": ".message.knowledge_graph.nodes[\"HP:0031819\"].name",
+			"value": "Increased waist to hip ratio",
+			"validation_type": "string"
+		},
+		{
+			"selector": ".message.results | map(select(.node_bindings.n1[0].id == \"HP:0004324\")) | .[0].node_bindings.n1[0].id",
+			"value": "HP:0004324",
+			"validation_type": "trapi.curie"
+		}
+	],
+	"payload": {
+		"message": {
+			"query_graph": {
+				"nodes": {
+					"n0": {
+						"ids": [
+							"MONDO:0005148"
+						],
+						"categories": [
+							"biolink:Disease"
+						]
+					},
+					"n1": {
+						"categories": [
+							"biolink:PhenotypicFeature"
+						]
+					}
+				},
+				"edges": {
+					"e01": {
+						"subject": "n0",
+						"object": "n1",
+						"predicates": [
+							"biolink:has_phenotype"
+						]
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is a real working example of a PR for the api-watchdog-translator-tests repo. The PR adds a single test targeting the Strider endpoint. A test is a JSON file containing an object with the keys

- name (str): The name of the test
- target (url): The endpoint that the test targets
- expectation(Array[Expectation]): A list of requirements that the response must meet for the test to pass.
- payload (object): The json passed to the endpoint.

Each expectation is an object with the keys
- selector (jq program): A string describing a [jq](https://stedolan.github.io/jq/) program that selects the one or more elements to test against
- value (Any): a value to test equality against
- validation_type (ValidationType): An API Watchdog validation type used to validate the value/response. The value/response will be implicitly converted to this type. For example, if you specify 'float' and the value is an integer it will be implicitly converted to a float. 

This test contains three expectations. The first two expectations check that the nodes "MONDO:0005148" (type 2 diabetes mellitus) and "HP:0031819" (Increased waist to hip ratio) are present in the knowledge graph while the last expectation is a more complicated one that checks that the two aforementioned nodes have an edge between them in the results.

To run this test, simply invoke
```
api-watchdog discover strider/diabetes_phenotype.watchdog.json
```
while in tests directory or

```
api-watchdog discover strider
```
to run all of the strider tests.

By default, the tests results will be outputted to stdout in abbreviated form. 

To save the full results as a json file specify the output path using the `-o` flag. 
