### PR TITLE
Change dockerfile to download release.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /api-watchdog/api-watchdog-0.3.0
 RUN chmod -R 777 .
 
 # install requirements
-RUN pip install .
+RUN pip install .[TRAPI]
 
 # Make a folder to put the fetch and exec script
 RUN mkdir /sandbox


### PR DESCRIPTION
Upgraded image to renciorg python image and removed the need to publish api-watchdog to pypi. This will require that we update these tests when we create a new release of api-watchdog. 